### PR TITLE
Fix: replace reactBasePrompt with nodeBasePrompt

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -39,7 +39,7 @@ app.post('/template', async (req, res) => {
     }
     if (answer=='node') {
       res.json({
-        prompts : [`Here is an artifact that contains all files of the project visible to you.\nConsider the contents of ALL files in the project.\n\n${reactBasePrompt}\n\nHere is a list of files that exist on the file system but are not being shown to you:\n\n  - .gitignore\n  - package-lock.json\n`],
+        prompts : [`Here is an artifact that contains all files of the project visible to you.\nConsider the contents of ALL files in the project.\n\n${nodeBasePrompt}\n\nHere is a list of files that exist on the file system but are not being shown to you:\n\n  - .gitignore\n  - package-lock.json\n`],
         uiprompts: [nodeBasePrompt],
       })
       return;


### PR DESCRIPTION
this commit replaces reactBasePrompt with nodeBasePrompt to correctly pass the node artifact for node application.